### PR TITLE
fix: correct comment menu positioning and map backend fields

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -454,6 +454,7 @@ i.user-avatar {
 
 .dropdown-container {
     position: relative;
+    margin-left: auto;
 }
 
 .dropdown-trigger {
@@ -811,9 +812,59 @@ figure {
   align-items: center;
   gap: 8px;
   margin-left: 40px;
+  position: relative;
 }
 .comment-content {
   margin-left: 40px;
+}
+
+/* Comment menu styles */
+.comment-menu-btn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--color-text-main);
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+}
+.comment-menu-btn:hover {
+  background-color: var(--color-border);
+}
+.comment-menu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background-color: var(--color-background-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+  min-width: 150px;
+  padding: 8px 0;
+}
+.comment-menu.hidden {
+  display: none;
+}
+.comment-menu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 16px;
+  border: none;
+  background: none;
+  color: var(--color-text-main);
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.2s;
+}
+.comment-menu button:hover {
+  background-color: var(--color-background-main);
+}
+.comment-menu button i {
+  width: 16px;
 }
 .view-more {
   background-color: var(--color-primary);

--- a/docs/scripts/Comment/commet.js
+++ b/docs/scripts/Comment/commet.js
@@ -2,8 +2,10 @@ class Comment {
     constructor(comment) {
         this.id = comment.id;
         this.userId = comment.userId;
-        this.imgOwner = comment.imgOwner;       
-        this.nameOwner = comment.nameOwner;     
+        // Backend sends: UserName and AvatarUrl
+        // Maintain compatibility with old data
+        this.imgOwner = comment.avatarUrl || comment.AvatarUrl || comment.imgOwner;       
+        this.nameOwner = comment.userName || comment.UserName || comment.nameOwner;     
         this.content = comment.text || comment.content || "";         
     } 
 
@@ -42,10 +44,11 @@ class Comment {
                         <button class="delete-comment">
                             <i class="fas fa-trash"></i> Eliminar
                         </button>
-                    ` : ''}
-                    <button class="report-comment">
-                        <i class="fas fa-flag"></i> Reportar
-                    </button>
+                    ` : `
+                        <button class="report-comment">
+                            <i class="fas fa-flag"></i> Reportar
+                        </button>
+                    `}
                 </div>
             </div>
 


### PR DESCRIPTION
- Add complete styles for comment hamburger menu with proper positioning
- Map backend fields: UserName/AvatarUrl to nameOwner/imgOwner
- Show Edit/Delete only on own comments, Report only on others' comments
- Fix post menu positioning with margin-left: auto
- Comment avatars and usernames now display correctly